### PR TITLE
the Division by zero ErrorException is possible here

### DIFF
--- a/src/Http/Controllers/CoinPaymentController.php
+++ b/src/Http/Controllers/CoinPaymentController.php
@@ -41,6 +41,9 @@ class CoinPaymentController extends Controller {
       $fiat = [];
       $coins_accept = [];
       foreach($rates as $i => $coin){
+          if ($rates[$i]['status'] !== 'online') continue;
+          if ($rates[$i]['rate_btc'] == 0) continue;
+
         if((INT) $coin['is_fiat'] === 0){
           $rate = ($rateAmount / $rates[$i]['rate_btc']);
           $coins[] = [


### PR DESCRIPTION
The main issues was we were getting "Division by zero" using your module. And there are currencies which are not online. I think it's better to skip it at all. This fixes those.
![2018-11-26_13-26-29](https://user-images.githubusercontent.com/6264719/49008936-34475c80-f180-11e8-985e-f44f1e1b3c0e.png)
