### PR TITLE
fix: unique name for routes

### DIFF
--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -33,8 +33,6 @@ class RouteServiceProvider extends ServiceProvider {
      */
     public function map()
     {
-        $this->mapApiRoutes();
-
         $this->mapWebRoutes();
     }
 
@@ -48,20 +46,5 @@ class RouteServiceProvider extends ServiceProvider {
     protected function mapWebRoutes() {
         Route::namespace($this->namespace)
             ->group(__DIR__ . '/../Routes/web.php');
-    }
-
-    /**
-     * Define the "api" routes for the application.
-     *
-     * These routes are typically stateless.
-     *
-     * @return void
-     */
-    protected function mapApiRoutes()
-    {
-        Route::prefix('api')
-            ->middleware('api')
-            ->namespace($this->namespace)
-            ->group(__DIR__ . '/../Routes/api.php');
     }
 }

--- a/src/Routes/web.php
+++ b/src/Routes/web.php
@@ -23,11 +23,10 @@ Route::as('coinpayment.')->prefix('coinpayment')
              */
             Route::group([
                 'prefix' => 'ajax',
-                'as' => 'ajax.'
             ], function() {
-                Route::get('/rates/{usd}', 'AjaxController@rates');
-                Route::post('/payload', 'AjaxController@encrypt_payload');
-                Route::post('/create', 'AjaxController@create_transaction');
+                Route::get('/rates/{usd}', 'AjaxController@rates')->name('rates');
+                Route::post('/payload', 'AjaxController@encrypt_payload')->name('encrypt.payload');
+                Route::post('/create', 'AjaxController@create_transaction')->name('create.transaction');
             });
         });
 
@@ -35,5 +34,5 @@ Route::as('coinpayment.')->prefix('coinpayment')
          * IPN handler
          * Please except into csrf proccess /coinpayment/ipn
          */
-        Route::post('/ipn', 'IPNController');
+        Route::post('/ipn', 'IPNController')->name('ipn');
     });


### PR DESCRIPTION
This fix compatibility with laravel 7, routes could not use the same name like "coinpayments.ajax." as is now.