### PR TITLE
fix: allow usage with laravel octane/swoole

### DIFF
--- a/src/Helpers/CoinPaymentHelper.php
+++ b/src/Helpers/CoinPaymentHelper.php
@@ -15,7 +15,6 @@ class CoinPaymentHelper {
 	 * Generate link payment
 	 *
 	 * @param [type] $array
-	 * @return void
 	 */
 	public function generatelink($array) {
 		if(!is_array($array)){
@@ -28,7 +27,6 @@ class CoinPaymentHelper {
 	 * Get raw transaction
 	 *
 	 * @param [type] $string
-	 * @return void
 	 */
 	public function getrawtransaction($string) {
 		return $this->transaction_dencrypt($string);
@@ -48,7 +46,6 @@ class CoinPaymentHelper {
 	 * Decripted transaction data
 	 *
 	 * @param String $string
-	 * @return void
 	 */
 	protected function transaction_dencrypt(String $string) {
 		return unserialize(Crypt::decryptString($string));
@@ -58,7 +55,6 @@ class CoinPaymentHelper {
 	 * Get status by txn ID
 	 *
 	 * @param [type] $txn_id
-	 * @return void
 	 */
 	public function getstatusbytxnid($txn_id) {
 		try {
@@ -90,8 +86,6 @@ class CoinPaymentHelper {
 
 	/**
 	 * Get balances
-	 *
-	 * @return void
 	 */
 	public function getBalances() {
 		return $this->api_call('balances');
@@ -99,8 +93,6 @@ class CoinPaymentHelper {
 
 	/**
 	 * Return to eloquent model transactions
-	 *
-	 * @return void
 	 */
 	public function gettransactions() {
 		return new CoinpaymentTransaction;
@@ -110,7 +102,6 @@ class CoinPaymentHelper {
 	 * Geherated top up address
 	 *
 	 * @param [type] $currency
-	 * @return void
 	 */
 	public function getDepositAddress($currency) {
 		return $this->api_call('get_deposit_address', [
@@ -122,7 +113,6 @@ class CoinPaymentHelper {
 	 * Create new withdrawal
 	 *
 	 * @param Array $body
-	 * @return void
 	 */
 	public function createWithdrawal(Array $body) {
 		return $this->api_call('create_withdrawal', $body);
@@ -132,7 +122,6 @@ class CoinPaymentHelper {
 	 * get withdrawal info
 	 *
 	 * @param String $body
-	 * @return void
 	 */
 	public function getWithdrawalInfo($id) {
 		return $this->api_call('get_withdrawal_info', $id);

--- a/src/Http/Controllers/IPNController.php
+++ b/src/Http/Controllers/IPNController.php
@@ -41,7 +41,7 @@ class IPNController extends Controller {
         }
         return response('No or incorrect Merchant ID passed', 401);
     }
-    $request = file_get_contents('php://input');
+    $request = $req->getContent();
     if ($request === FALSE || empty($request)) {
         if(!empty($cp_debug_email)) {
             \Mail::to($cp_debug_email)->send(new SendEmail([

--- a/src/Http/Controllers/IPNController.php
+++ b/src/Http/Controllers/IPNController.php
@@ -52,7 +52,7 @@ class IPNController extends Controller {
         return response('Error reading POST data', 401);
     }
     $hmac = hash_hmac("sha512", $request, trim($cp_ipn_secret));
-    if (!hash_equals($hmac, $_SERVER['HTTP_HMAC'])) {
+    if (!hash_equals($hmac, $req->server('HTTP_HMAC'))) {
         if(!empty($cp_debug_email)) {
             \Mail::to($cp_debug_email)->send(new SendEmail([
                 'message' => 'HMAC signature does not match'


### PR DESCRIPTION
Swoole doesn't allow usage of `php://input`, so we need to use the stream from the `$req` object to achieve the same behavior.